### PR TITLE
Add Correlation table and moving isx funtions to another file

### DIFF
--- a/cgk_calcium_tools/analysis_utils.py
+++ b/cgk_calcium_tools/analysis_utils.py
@@ -5,10 +5,9 @@ import numpy as np
 import os
 from .files_io import write_log_file, same_json_or_remove, parameters_for_isx
 
-def compute_traces_corr(fh, cellsetname: str, verbose=False) -> pd.DataFrame:
+def compute_traces_corr(cell_set_files: list, corr_files: list, verbose=False) -> pd.DataFrame:
     """
-    This function runs the isx.cell_metrics function, which compute cell metrics
-    for a given cell set and events combination
+    This function compute the correlation matrix for the cell traces.
 
     Parameters
     ----------
@@ -22,16 +21,9 @@ def compute_traces_corr(fh, cellsetname: str, verbose=False) -> pd.DataFrame:
     Returns
     -------
     pd.DataFrame
-        a concatenates list with metrics
-
-
+        DataFrame with the correlation matrix
     """
-    cell_set_files = fh.get_results_filenames(
-        f"{cellsetname}", op=None, single_plane=False
-    )
-    corr_files = fh.get_results_filenames(
-        f"{cellsetname}_corr.csv", op=None, single_plane=False
-    )
+
     for cellset, corr_file in zip(cell_set_files, corr_files):
         inputs_args = {
             "input_cell_set_file": os.path.basename(cellset),

--- a/cgk_calcium_tools/analysis_utils.py
+++ b/cgk_calcium_tools/analysis_utils.py
@@ -48,9 +48,9 @@ def compute_traces_corr(fh, cellsetname: str, verbose=False) -> pd.DataFrame:
             num_cells = cs.num_cells
             corr = np.zeros((num_cells, num_cells))
             for i in range(num_cells-1):
-                tr1 = cs.get_cell_trace(i)
+                tr1 = cs.get_cell_trace_data(i)
                 for j in range(i+1, num_cells):
-                    tr2 = cs.get_cell_trace(j)
+                    tr2 = cs.get_cell_trace_data(j)
                     corr[i, j] = np.corrcoef(tr1, tr2)[0, 1]
                     corr[j, i] = corr[i, j]
             labels = [cs.get_cell_name(i) for i in range(cs.num_cells)]

--- a/cgk_calcium_tools/filehandler.py
+++ b/cgk_calcium_tools/filehandler.py
@@ -214,6 +214,7 @@ class isx_files_handler:
                             + "_metadata.json",
                         )
                         if os.path.exists(json_file):
+                            pb.update_progress_bar(1)
                             continue
 
                     # Read the video file and grab metadata information

--- a/cgk_calcium_tools/isx_aux_functions.py
+++ b/cgk_calcium_tools/isx_aux_functions.py
@@ -1,6 +1,7 @@
 import isx
 import numpy as np
-
+import os
+from typing import Iterable
 
 def create_empty_events(cell_set_file,ed_file):
     """
@@ -67,3 +68,97 @@ def cellset_is_empty(cellset: str, accepted_only:bool = True):
     del cs  # isx keeps the file open otherwise
     
     return is_empty
+
+
+def get_segment_from_movie(
+    inputfile: str,
+    outputfile: str,
+    borders: Iterable,
+    keep_start_time=False,
+    unit="minutes",
+) -> None:
+    """
+    This function gets a segment of a video to create a new one. It's just an easy
+    handler of isx.trim_movie, which trim frames from a movie to produce a new movie
+
+    Parameters
+    ----------
+    inputfile : str
+        Path of the input file to use
+    outputfile : str
+        Path of the output file to use
+    borders: iterable
+        With two elements of the borders in minutes (integers) of the segment.
+        Where negative times means from the end like indexing in a numpy array
+    keep_start_time : Bool, optional
+        If true, keep the start time of the movie, even if some of its
+        initial frames are to be trimmed, by default False
+    unit: str
+        the unit to use for border. It could be 'minutes' or 'seconds'
+
+    Returns
+    -------
+    None
+
+    Examples
+    --------
+    >>> get_segment_from_movie('inputfile.isxd','output.isxd',[-30, -1]) #last 30 minutes
+
+    """
+    assert len(borders) == 2, "borders must have two elements"
+    assert unit in ["minutes", "seconds"], """unit could be 'minutes' or 'seconds'. """
+    movie = isx.Movie.read(inputfile)
+    if unit == "minutes":
+        unitfactor = 60
+    else:
+        unitfactor = 1
+    numframes = movie.timing.num_samples
+    duration_unit = numframes * movie.timing.period.to_msecs() / (1000 * unitfactor)
+    timing_period_unit = movie.timing.period.to_msecs() / (1000 * unitfactor)
+
+    movie.flush()
+
+    crop_segments = []
+    assert (
+        borders[0] > -duration_unit
+    ), "asking for a segment from {minutes[0]} {unit} before the end, but video is {duration_minutes} {unit} long."
+    assert (
+        borders[0] < duration_unit
+    ), "asking for a segment from {minutes[0]} {unit}, but video is {duration_minutes} {unit} long."
+    assert (
+        borders[1] < duration_unit
+    ), "asking for a segment up to {minutes[0]} {unit}, but video is {duration_minutes} {unit} long."
+    assert (
+        borders[1] > -duration_unit
+    ), "asking for a segment up to {minutes[0]} {unit} before the end, but video is {duration_minutes} {unit} long."
+
+    # remove fist frames:
+    # don't cut if the segments are from the beggining or just exactlt
+    # duration before the end
+    if borders[0] != 0 and borders[0] != -duration_unit:
+        if borders[0] < 0:
+            end1 = (duration_unit + borders[0]) / timing_period_unit - 1
+        else:
+            end1 = borders[0] / timing_period_unit - 1
+        crop_segments.append([0, int(end1)])
+    # remove last frames:
+    # and don't cut if the segments are up to the end or just the exact
+    # duration
+    if borders[1] != -1 and borders[1] != duration_unit:
+        if borders[1] < 0:
+            start1 = (duration_unit + borders[1] + 1) / timing_period_unit + 1
+        else:
+            start1 = borders[1] / timing_period_unit + 1
+        crop_segments.append([int(start1), numframes])
+
+    if os.path.exists(outputfile):
+        os.remove(outputfile)
+    if len(crop_segments) == 0:
+        print("no trim need it")
+        return
+    isx.trim_movie(
+        input_movie_file=inputfile,
+        output_movie_file=outputfile,
+        crop_segments=np.array(crop_segments),
+        keep_start_time=keep_start_time,
+    )

--- a/cgk_calcium_tools/isx_aux_functions.py
+++ b/cgk_calcium_tools/isx_aux_functions.py
@@ -3,6 +3,31 @@ import numpy as np
 import os
 from typing import Iterable
 
+def get_efocus(gpio_file: str) -> list:
+    """
+    Read the gpio set from a file and get the data associated.
+
+    Parameters
+    ----------
+    gpio_file : str
+        path of gpio file
+
+    Returns
+    -------
+    list
+        list with the video_efocus
+
+    """
+    gpio_set = isx.GpioSet.read(gpio_file)
+    efocus_values = gpio_set.get_channel_data(gpio_set.channel_dict["e-focus"])[1]
+    efocus_values, efocus_counts = np.unique(efocus_values, return_counts=True)
+    min_frames_per_efocus = 100
+    video_efocus = efocus_values[efocus_counts >= min_frames_per_efocus]
+    assert (
+        video_efocus.shape[0] < 4
+    ), f"{gpio_file}: Too many efocus detected, early frames issue."
+    return [int(v) for v in video_efocus]
+
 def create_empty_events(cell_set_file,ed_file):
     """
     Creates an empty event set file with the timing information from a given cell set file.

--- a/cgk_calcium_tools/pipeline_functions.py
+++ b/cgk_calcium_tools/pipeline_functions.py
@@ -1,0 +1,261 @@
+import isx
+from typing import Union,  Tuple
+from .processing import fix_frames
+from typing import Callable
+from .files_io import (
+    write_log_file,
+    same_json_or_remove,
+    parameters_for_isx,
+)
+import os
+import numpy as np
+f_register: dict[str, Callable] = {}
+f_message: dict[str, str] = {}
+def register(name: Union[str, list],message=None) -> None:
+    
+    if message is None:
+        message = f"Running function: {name}"
+
+    def decorator(func: Callable) -> None:
+        assert isinstance(func, Callable)
+        if isinstance(name, list):
+            for n in name:
+                f_register[n] = func
+
+        else:
+            f_register[name] = func
+        f_message[name] = message
+    return decorator
+
+        
+@register(['isx:spatial_filter', "spatial_filter"],"Preprocessing")
+def isx_spatial_filter(input, output, parameters, verbose) -> None:
+    """
+    Applies spatial bandpass filtering to each frame of one or more movies
+
+    Parameters
+    ----------
+    parameters : dict
+        Parameter dictionary of executed functions.
+    verbose : bool, optional
+        Show additional messages, by default False
+    Returns
+    -------
+    None
+
+    """
+
+    parameters_rel = parameters.copy()
+    parameters_rel.update(
+        {
+            "input_movie_files": os.path.basename(parameters["input_movie_files"]),
+            "output_movie_files": os.path.basename(parameters["output_movie_files"])
+        }
+    )
+
+
+    if same_json_or_remove(
+        parameters_rel,
+        input_files_keys=["input_movie_files"],
+        output=parameters["output_movie_files"],
+        verbose=verbose,
+    ):
+        return
+    isx.spatial_filter(
+        **parameters_for_isx(
+            parameters,
+            ["comments"],
+            {"input_movie_files": input, "output_movie_files": output},
+        )
+    )
+    write_log_file(
+        parameters_rel,
+        os.path.dirname(output),
+        {"function": "spatial_filter"},
+        input_files_keys=["input_movie_files"],
+        output_file_key="output_movie_files",
+    )
+    if verbose:
+        print("{} bandpass filtering completed".format(output))
+
+
+
+@register(['isx:motion_correct', "motion_correct"],"Applying Motion Correction to")
+def isx_motion_correct(input, output, parameters, verbose) -> None:
+    """
+    After checks, use the isx.motion_correct function, which motion correct movies to a reference frame.
+
+    Parameters
+    ----------
+    parameters : dict
+       Parameter list of executed functions.
+    verbose : bool, optional
+        Show additional messages, by default False
+
+    Returns
+    -------
+    None
+
+    Examples
+    --------
+    """
+    # Initialize progress bar
+
+    translation_file = os.path.splitext(output)[0] + "-translations.csv"
+    crop_rect_file = os.path.splitext(output)[0] + "-crop_rect.csv"
+
+    new_data = {
+        "input_movie_files": os.path.basename(input),
+        "output_movie_files": os.path.basename(output),
+        "output_translation_files": os.path.basename(translation_file),
+        "output_crop_rect_file": os.path.basename(crop_rect_file),
+    }
+    parameters.update(new_data)
+    if same_json_or_remove(
+        parameters,
+        input_files_keys=["input_movie_files"],
+        output=output,
+        verbose=verbose,
+    ):
+        return
+    isx.motion_correct(
+        **parameters_for_isx(
+            parameters,
+            ["comments"],
+            {
+                "input_movie_files": input,
+                "output_movie_files": output,
+                "output_translation_files": translation_file,
+                "output_crop_rect_file": crop_rect_file,
+            },
+        )
+    )
+    write_log_file(
+        parameters,
+        os.path.dirname(output),
+        {"function": "motion_correct"},
+        input_files_keys=["input_movie_files"],
+        output_file_key="output_movie_files",
+    )
+
+    if verbose:
+        print("{} motion correction completed".format(output))
+
+
+@register(['isx:preprocessing', "preprocessing"],"Applying Bandpass Filter to")
+def isx_preprocessing(input, output, parameters, verbose) -> None:
+    """
+    After performing checks, use the isx.preprocess function, which preprocesses movies,
+    optionally applying spatial and temporal downsampling and cropping.
+
+    Parameters
+    ----------
+
+    parameters : dict
+       Parameter dictionary of executed functions.
+    verbose : bool, optional
+        Show additional messages, by default False
+
+    Returns
+    -------
+    None
+
+    """
+    if isinstance(parameters["spatial_downsample_factor"], str):
+        res_idx, value = parameters["spatial_downsample_factor"].split("_")
+        if res_idx == "maxHeight":
+            idx_resolution = 0
+        elif res_idx == "maxWidth":
+            idx_resolution = 1
+        else:
+            assert False, "error in sp_downsampling parameter value"
+        movie = isx.Movie.read(input)
+        resolution = movie.spacing.num_pixels
+        del movie
+        parameters["spatial_downsample_factor"] = np.ceil(
+            resolution[idx_resolution] / float(value)
+        )
+
+    parameters.update(
+        {
+            "input_movie_files": os.path.basename(input),
+            "output_movie_files": os.path.basename(output),
+        }
+    )
+
+    if same_json_or_remove(
+        parameters,
+        input_files_keys=["input_movie_files"],
+        output=output,
+        verbose=verbose,
+    ):
+        return
+
+    isx.preprocess(
+        **parameters_for_isx(
+            parameters,
+            ["comments", "fix_frames_th_std"],
+            {"input_movie_files": input, "output_movie_files": output},
+        )
+    )
+
+    nfixed = fix_frames(output, std_th=parameters["fix_frames_th_std"], report=True)
+
+    write_log_file(
+        parameters,
+        os.path.dirname(output),
+        {"function": "preprocess"},
+        input_files_keys=["input_movie_files"],
+        output_file_key="output_movie_files",
+    )
+    if verbose:
+        print("{} preprocessing completed. {} frames fixed.".format(output, nfixed))
+
+
+
+@register(['isx:dff', "dff"],"Normalizing via DF/F0")
+def isx_dff(input, output, parameters, verbose) -> None:
+
+    """
+    This function applies isx.dff function, to compute the DF/F movies.
+
+    Parameters
+    ----------
+    overwrite : bool, optional
+        Remove results and recompute them, by default False
+    verbose : bool, optional
+        Show additional messages, by default False
+
+    Returns
+    -------
+    None
+
+    """
+    
+    new_data = {
+        "input_movie_files": os.path.basename(input),
+        "output_movie_files": os.path.basename(output),
+    }
+    parameters.update(new_data)
+    if same_json_or_remove(
+        parameters,
+        input_files_keys=["input_movie_files"],
+        output=output,
+        verbose=verbose,
+    ):
+        return
+    isx.dff(
+        **parameters_for_isx(
+            parameters,
+            ["comments"],
+            {"input_movie_files": input, "output_movie_files": output},
+        )
+    )
+    write_log_file(
+        parameters,
+        os.path.dirname(output),
+        {"function": "dff"},
+        input_files_keys=["input_movie_files"],
+        output_file_key="output_movie_files",
+    )
+

--- a/cgk_calcium_tools/pipeline_functions.py
+++ b/cgk_calcium_tools/pipeline_functions.py
@@ -18,13 +18,11 @@ def register(name: Union[str, list],message=None) -> None:
 
     def decorator(func: Callable) -> None:
         assert isinstance(func, Callable)
-        if isinstance(name, list):
-            for n in name:
-                f_register[n] = func
-
-        else:
-            f_register[name] = func
-        f_message[name] = message
+        if not isinstance(name, list):
+            name = [name]
+        for n in name:
+            f_register[n] = func
+            f_message[name] = message
     return decorator
 
         

--- a/cgk_calcium_tools/pipeline_functions.py
+++ b/cgk_calcium_tools/pipeline_functions.py
@@ -11,17 +11,19 @@ import os
 import numpy as np
 f_register: dict[str, Callable] = {}
 f_message: dict[str, str] = {}
-def register(name: Union[str, list],message=None) -> None:
+def register(name: Union[str, list], message=None) -> None:
     
     if message is None:
         message = f"Running function: {name}"
 
     def decorator(func: Callable) -> None:
         assert isinstance(func, Callable)
-        if not isinstance(name, list):
-            name = [name]
-        for n in name:
-            f_register[n] = func
+        if  isinstance(name, list):            
+            for n in name:
+                f_register[n] = func
+                f_message[n] = message
+        else:
+            f_register[name] = func
             f_message[name] = message
     return decorator
 

--- a/cgk_calcium_tools/pipeline_functions.py
+++ b/cgk_calcium_tools/pipeline_functions.py
@@ -260,6 +260,56 @@ def isx_dff(input, output, parameters, verbose) -> None:
     )
 
 
+@register(['isx:project_movie', "project_movie"],"Projecting Movies")
+def project_movie(input, output, parameters: dict, verbose:bool=False) -> None:
+    """
+    This function applies isx.project_movie to project movies to a single statistic image.
+
+    Parameters
+    ----------
+    overwrite : bool, optional
+        Remove results and recompute them, by default False
+    verbose : bool, optional
+        Show additional messages, by default False
+
+    Returns
+    -------
+    None
+
+    """
+    new_data = {
+        "input_movie_files": os.path.basename(input),
+        "output_image_file": os.path.basename(output),
+    }
+    parameters.update(new_data)
+    if same_json_or_remove(
+        parameters,
+        input_files_keys=["input_movie_files"],
+        output=output,
+        verbose=verbose,
+    ):
+        return
+    isx.project_movie(
+        **parameters_for_isx(
+            parameters,
+            ["comments"],
+            {"input_movie_files": input, "output_image_file": output},
+        )
+    )
+    write_log_file(
+        parameters,
+        os.path.dirname(output),
+        {"function": "project_movie"},
+        input_files_keys=["input_movie_files"],
+        output_file_key="output_image_file",
+    )
+
+
+
+
+
+
+
 def de_interleave(main_file, planes_fs, focus, overwrite: bool = False) -> None:
     """
     This function applies the isx.de_interleave function, which de-interleaves multiplane movies


### PR DESCRIPTION
First this PR add the compute_traces_corr function  to create a table with the correlation between traces.  

But.. I included a few more changes:
- The change to do the de-interleave automatically with the first step, and I move it to another file to reduce file_handlerpy.
- A new .py with the content of a few steps (just the parameters and logs parts) in this way the mehod  run_steps is smaller and cleaner. And it will make easy to include another types of motion correction just changing the function to run.

